### PR TITLE
add libsecp256k1 to accelerate ECDSA operations

### DIFF
--- a/libsecp256k1.json
+++ b/libsecp256k1.json
@@ -1,6 +1,9 @@
 {
     "name": "libsecp256k1",
-    "config-opts": [ "--disable-static" ],
+    "config-opts": [
+        "--enable-module-recovery",
+        "--disable-static"
+    ],
     "cleanup": [
         "/lib/*.la",
         "/lib/pkgconfig"
@@ -9,7 +12,7 @@
         {
             "type": "git",
             "url": "https://github.com/bitcoin-core/secp256k1",
-            "commit": "3a6fd7f636da5c6ee0702ab0ac40ff9f99753b7b"
+            "commit": "HEAD"
         }
     ],
     "post-install": [

--- a/libsecp256k1.json
+++ b/libsecp256k1.json
@@ -1,0 +1,18 @@
+{
+    "name": "libsecp256k1",
+    "config-opts": [ "--disable-static" ],
+    "cleanup": [
+        "/lib/*.la",
+        "/lib/pkgconfig"
+    ],
+    "sources": [
+        {
+            "type": "git",
+            "url": "https://github.com/bitcoin-core/secp256k1",
+            "commit": "3a6fd7f636da5c6ee0702ab0ac40ff9f99753b7b"
+        }
+    ],
+    "post-install": [
+        "install -Dm644 COPYING /app/share/licenses/libsecp256k1/COPYING"
+    ]
+}

--- a/org.electrum.electrum.json
+++ b/org.electrum.electrum.json
@@ -21,6 +21,7 @@
         "--share=network"
     ],
     "modules": [
+        "libsecp256k1.json",
         "python3-modules.json",
         "python3-pycryptodomex.json",
         "python3-pyQt5.json",


### PR DESCRIPTION
There is optimized library for ECDSA, used in electrum builds (see contrib):
https://github.com/bitcoin-core/secp256k1

Maybe it should be included in flatpak build.